### PR TITLE
feat: support new thoughts format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 This repository contains a fully client‑side implementation of a “Thought
 for the Day” devotional.  Entries were converted from the source
 document provided by the user and stored in `data/thoughts.json` as an
-array of objects.  Each object has an `id` (zero‑based), an optional
-`title`, an optional `study_refs` array, and a safe HTML fragment
-under `html`.
+array of objects.  Each object contains a `day` (1‑based) and a
+`body_text` field holding the complete HTML string for that day’s
+devotional.  The HTML must not include `<script>` or `<img>` tags or
+any inline event handlers; such entries are rejected at run time.
 
 The site consists of a single HTML page (`index.html`) with a small
 stylesheet (`assets/styles.css`) and a script (`assets/app.js`).  On

--- a/assets/app.js
+++ b/assets/app.js
@@ -5,7 +5,8 @@
   // Path to our JSON data file.  A relative path is important so that
   // the app works both locally and when hosted from a subdirectory on
   // GitHub Pages.  The file must exist and contain a JSON array of
-  // objects as described in the project brief.
+  // objects where each entry has the shape:
+  //   { "day": <number>, "body_text": <html string> }
   const DATA_URL = "data/thoughts.json";
 
   // We must always use the Europe/London time zone when computing
@@ -59,12 +60,16 @@
 
   /**
    * Minimal validation of HTML fragments.  Reject anything that
-   * contains script tags or inline event handlers.  We trust that
-   * entries were sanitised at build time.
+   * contains script tags, image tags or inline event handlers.  We trust
+   * that entries were sanitised at build time.
    */
   function isValidHTML(html) {
     if (typeof html !== "string" || !html.trim()) return false;
-    if (/<\s*script/i.test(html) || /on\w+\s*=/.test(html)) return false;
+    if (
+      /<\s*script/i.test(html) ||
+      /<\s*img/i.test(html) ||
+      /on\w+\s*=/.test(html)
+    ) return false;
     return true;
   }
 
@@ -90,11 +95,11 @@
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const arr = await res.json();
       const clean = Array.isArray(arr)
-        ? arr.filter(o => o && Number.isInteger(o.id) && isValidHTML(o.html))
+        ? arr.filter(o => o && Number.isInteger(o.day) && isValidHTML(o.body_text))
         : [];
       if (clean.length === 0) throw new Error('No valid thoughts found');
-      // sort by id ascending just in case
-      state.thoughts = clean.sort((a, b) => a.id - b.id);
+      // sort by day ascending just in case
+      state.thoughts = clean.sort((a, b) => a.day - b.day);
       state.idx = chooseIndex(state.thoughts.length);
       state.today = state.thoughts[state.idx];
       render(metaEl, thoughtEl);
@@ -126,10 +131,9 @@
       return;
     }
     const total = state.thoughts.length;
-    // Use title if present, else use day (if available) or id+1
-    const label = t.title ? `${t.title}` : (t.day ? `Day ${t.day}` : `Day ${t.id + 1}`);
+    const label = `Day ${t.day}`;
     metaEl.textContent = `${label} • entry ${state.idx + 1} of ${total}`;
-    thoughtEl.innerHTML = t.html;
+    thoughtEl.innerHTML = t.body_text;
     // Normalise links: add noopener and open in new tab if not already specified
     thoughtEl.querySelectorAll('a[href]').forEach(a => {
       a.setAttribute('rel', 'noopener');


### PR DESCRIPTION
## Summary
- parse new `thoughts.json` entries with `day` and `body_text`
- render entry HTML and label using the `day` field
- document updated JSON structure in README
- reject `<img>` tags alongside scripts and inline handlers

## Testing
- `node --version`
- `node --check assets/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0654b7f488320913451b0c103e1b1