### PR TITLE
Normalize red text styling

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -134,6 +134,13 @@
     const label = `Day ${t.day}`;
     metaEl.textContent = `${label} • entry ${state.idx + 1} of ${total}`;
     thoughtEl.innerHTML = t.body_text;
+    thoughtEl.querySelectorAll('span[style]').forEach(span => {
+      const style = span.getAttribute('style');
+      if (style && /color:\s*#C9211E/i.test(style)) {
+        span.classList.add('red-text');
+        span.removeAttribute('style');
+      }
+    });
     // Normalise links: add noopener and open in new tab if not already specified
     thoughtEl.querySelectorAll('a[href]').forEach(a => {
       a.setAttribute('rel', 'noopener');

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -49,6 +49,10 @@ h1 {
   color: #c00;
 }
 
+.red-text {
+  color: #C9211E;
+}
+
 .foot {
   margin: 2rem 0;
   color: var(--muted);


### PR DESCRIPTION
## Summary
- add dedicated `.red-text` class for red colour
- sanitize inline red spans in render by converting to `red-text` class

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c09a30176c832098754004882dcb0d