### PR TITLE
Normalize red text styling and ignore image tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This repository contains a fully client‑side implementation of a “Thought
 for the Day” devotional.  Entries were converted from the source
 document provided by the user and stored in `data/thoughts.json` as an
-array of objects.  Each object contains a `day` (1‑based) and a
-`body_text` field holding the complete HTML string for that day’s
+array of objects.  Each object contains a `day` (1‑based) and an
+`html` field holding the complete HTML string for that day’s
 devotional.
 
 The site consists of a single HTML page (`index.html`) with a small

--- a/assets/app.js
+++ b/assets/app.js
@@ -6,7 +6,7 @@
   // the app works both locally and when hosted from a subdirectory on
   // GitHub Pages.  The file must exist and contain a JSON array of
   // objects where each entry has the shape:
-  //   { "day": <number>, "body_text": <html string> }
+  //   { "day": <number>, "html": <html string> }
   const DATA_URL = "data/thoughts.json";
 
   // We must always use the Europe/London time zone when computing
@@ -59,18 +59,28 @@
   }
 
   /**
-   * Minimal validation of HTML fragments.  Reject anything that
-   * contains script tags, image tags or inline event handlers.  We trust
+   * Minimal validation of HTML fragments. Reject anything that
+   * contains script tags or inline event handlers. Image tags are
+   * stripped elsewhere so we simply ignore them here. We trust
    * that entries were sanitised at build time.
    */
   function isValidHTML(html) {
     if (typeof html !== "string" || !html.trim()) return false;
     if (
       /<\s*script/i.test(html) ||
-      /<\s*img/i.test(html) ||
       /on\w+\s*=/.test(html)
     ) return false;
     return true;
+  }
+
+  /**
+   * Remove image tags from an HTML fragment. Returns the input string
+   * with any <img> elements removed.
+   */
+  function stripImages(html) {
+    return typeof html === "string"
+      ? html.replace(/<\s*img[^>]*>/gi, "")
+      : html;
   }
 
   /**
@@ -95,7 +105,13 @@
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const arr = await res.json();
       const clean = Array.isArray(arr)
-        ? arr.filter(o => o && Number.isInteger(o.day) && isValidHTML(o.body_text))
+        ? arr
+            .map(o => {
+              if (!o || !Number.isInteger(o.day) || typeof o.html !== "string") return null;
+              const sanitized = stripImages(o.html);
+              return isValidHTML(sanitized) ? { day: o.day, body_text: sanitized } : null;
+            })
+            .filter(Boolean)
         : [];
       if (clean.length === 0) throw new Error('No valid thoughts found');
       // sort by day ascending just in case
@@ -134,6 +150,13 @@
     const label = `Day ${t.day}`;
     metaEl.textContent = `${label} • entry ${state.idx + 1} of ${total}`;
     thoughtEl.innerHTML = t.body_text;
+    thoughtEl.querySelectorAll('span[style]').forEach(span => {
+      const style = span.getAttribute('style');
+      if (style && /color:\s*#C9211E/i.test(style)) {
+        span.classList.add('red-text');
+        span.removeAttribute('style');
+      }
+    });
     // Normalise links: add noopener and open in new tab if not already specified
     thoughtEl.querySelectorAll('a[href]').forEach(a => {
       a.setAttribute('rel', 'noopener');

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -49,6 +49,10 @@ h1 {
   color: #c00;
 }
 
+.red-text {
+  color: #C9211E;
+}
+
 .foot {
   margin: 2rem 0;
   color: var(--muted);


### PR DESCRIPTION
## Summary
- add dedicated `.red-text` class for red colour
- sanitize inline red spans in render by converting to `red-text` class
- strip `<img>` tags during load and relax HTML checks to ignore them
- read entries from `html` field in `thoughts.json`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c09a30176c832098754004882dcb0d