### PR TITLE
Deduplicate repeated "Prayer" label in parsed prayer output

### DIFF
--- a/prepare_thoughts_v2.py
+++ b/prepare_thoughts_v2.py
@@ -107,6 +107,12 @@ class RobustThoughtProcessor:
             result = pattern.sub('', result).strip()
         return result
 
+    def _normalize_prayer_text(self, text: str) -> str:
+        """Remove duplicated prayer labels from prayer content text."""
+        normalized = self._strip_label(text)
+        normalized = re.sub(r'^\*?\*?\s*prayer\*?\*?\s*[,:\-–—]?\s*', '', normalized, count=1, flags=re.IGNORECASE)
+        return normalized.strip()
+
     def _looks_like_scripture_reference(self, text: str) -> bool:
         scripture_patterns = [
             r'\d+\s*:\s*\d+',
@@ -295,7 +301,7 @@ class RobustThoughtProcessor:
                 state['awaiting_scripture_text'] = False
                 state['in_devotional'] = True
             elif classification == "PRAYER":
-                current_entry["prayer"] = self._strip_label(raw_text)
+                current_entry["prayer"] = self._normalize_prayer_text(raw_text)
                 state['in_devotional'] = False
             elif classification == "BIBLE_READING":
                 current_entry["bible_reading"] = self._strip_label(raw_text)


### PR DESCRIPTION
### Motivation
- Prevent generated HTML from showing duplicated prayer labels like "Prayer: Prayer..." when the source paragraph already begins with the word "Prayer" or variants such as `**Prayer**`.

### Description
- Added a helper `def _normalize_prayer_text(self, text: str) -> str` that first applies existing label stripping and then removes a leading `prayer` token (including variants like `Prayer:`, `Prayer,-`, or `**Prayer**`) using a case-insensitive regex.
- Updated the PRAYER handling in `prepare_thoughts_v2.py` to use `_normalize_prayer_text(...)` instead of the previous plain label stripping so parsed entries no longer include duplicated prefixes.

### Testing
- Successfully type-checked/compiled the module with `python -m py_compile prepare_thoughts_v2.py` (no syntax errors).
- Performed a local regex sanity check with representative strings confirming `"Prayer: Prayer, Father..."` becomes `"Father..."` as expected.
- Attempted to instantiate `RobustThoughtProcessor` in an interactive check but the run failed due to a missing third-party dependency (`ModuleNotFoundError: No module named 'docx'`), so full end-to-end parsing was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb0f1fe98832080b3ea3ba773bf09)